### PR TITLE
Comment by 我自己 on p20190608235700

### DIFF
--- a/_data/comments/p20190608235700/842be591.yml
+++ b/_data/comments/p20190608235700/842be591.yml
@@ -1,0 +1,17 @@
+id: 842be591
+date: 2021-07-13T09:31:05.6686415Z
+name: 我自己
+email: wo@w.com
+score: Not configured
+message: >-
+  在2021-07-13 17:29:39更新：
+
+  只有verySync 这样的p2p文件同步工具才是从安装到使用上，都是比seafile/NextCloud之流便捷100倍的。
+
+
+
+  在2020-05-19 07:36:07更新：
+
+  我最近使用了seafile和nextCloud. 尝试了布署他们。但是我发现：nextCloud的优点在于文档更为整洁，缺点在于无法让用户自行注册账户，需要管理员开设新的账户。seafile 的优点主要在于开放注册和简洁。seafile的开发者，说句不客套的评论，与nextCloud的开发者比起来，显得略微业余（凌乱和bug）。也就是说，seafile在布署的过程中会遇到各种问题。无论是在x64 Linux还是arm64上，我都做了测试。仅仅在x64 Linux上, 使用Docker来布署seafile-mc:latest。能用文件同步功能，但都存在上传失败的bug。不过作为一只仅5-6个核心开发者的团队，seafile的开发者非常值得赞赏，他们付出了很多努力，我们应该支持他们。
+
+  如果你是轻量级的NAS用户，考虑到布署的难度，还是选择nextCloud吧。


### PR DESCRIPTION
avatar: <img src="" width="64" height="64" />

Score: Not configured

在2021-07-13 17:29:39更新：
只有verySync 这样的p2p文件同步工具才是从安装到使用上，都是比seafile/NextCloud之流便捷100倍的。

在2020-05-19 07:36:07更新：
我最近使用了seafile和nextCloud. 尝试了布署他们。但是我发现：nextCloud的优点在于文档更为整洁，缺点在于无法让用户自行注册账户，需要管理员开设新的账户。seafile 的优点主要在于开放注册和简洁。seafile的开发者，说句不客套的评论，与nextCloud的开发者比起来，显得略微业余（凌乱和bug）。也就是说，seafile在布署的过程中会遇到各种问题。无论是在x64 Linux还是arm64上，我都做了测试。仅仅在x64 Linux上, 使用Docker来布署seafile-mc:latest。能用文件同步功能，但都存在上传失败的bug。不过作为一只仅5-6个核心开发者的团队，seafile的开发者非常值得赞赏，他们付出了很多努力，我们应该支持他们。
如果你是轻量级的NAS用户，考虑到布署的难度，还是选择nextCloud吧。